### PR TITLE
fix skip-database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.0 - WIP
+## 0.4.0 - 2023-02-04
 - Support for Laravel 10
 - Add requirements check for Laravel 10
 - GitHub Actions Workflows: cleaning and fine-tuning
@@ -8,7 +8,8 @@
 - Using PestPHP for testing
 - Removing Makefile and using composer scripts to launching code quality tools
 - migrating tests from PHPUnit to PestPHP, thanks to @dansysanalyst
-- 
+- Fix skip-database option, now with works with all "show" options. Before the fix it worked only with "show all" option. 
+
 ## 0.3.1- 2022-07-17
 - Fine tuning dependencies for PHP 8.1, and Symfony / Doctrine packages
 - Drop supprt for PHP7.4, for older PHP and Laravel, use Laralens v0.2.x

--- a/src/Console/LaraLensCommand.php
+++ b/src/Console/LaraLensCommand.php
@@ -133,10 +133,6 @@ class LaraLensCommand extends Command
                 $show = self::OPTION_SHOW_NONE;
                 if (in_array("all", $showOptions)) {
                     $show = self::OPTION_SHOW_ALL;
-                    $skipDatabases = $this->option("skip-database");
-                    if ($skipDatabases) {
-                        $show = self::OPTION_SHOW_ALL - self::OPTION_SHOW_DATABASE - self::OPTION_SHOW_MIGRATION;
-                    }
                 } else {
                     $show = (in_array("config", $showOptions)) ? $show | self::OPTION_SHOW_CONFIGS : $show ;
                     $show = (in_array("runtime", $showOptions)) ? $show | self::OPTION_SHOW_RUNTIMECONFIGS : $show ;
@@ -150,6 +146,10 @@ class LaraLensCommand extends Command
             } else {
                 $show = self::OPTION_SHOW_DEFAULT;
             }
+        }
+        $skipDatabases = $this->option("skip-database");
+        if ($skipDatabases) {
+            $show = $show - self::OPTION_SHOW_DATABASE - self::OPTION_SHOW_MIGRATION;
         }
 
         $this->widthLabel = $this->option("width-label");


### PR DESCRIPTION
Fix skip-database option; now with works with all "show" options. Before the fix, it worked only with "show all" option